### PR TITLE
Rf mockup0.8

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -4,4 +4,5 @@
 
 
 # Other Key Contributions:
-
+* Joshua Giles - Dell Inc. -- Dell Extreme Scale Infrastructure (ESI)
+* Abhiram Ampabathina - Dell Inc. -- Dell Extreme Scale Infrastructure (ESI) Software Developer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 
 # Change Log
 
+## [0.9.2] - 2017-04-28
+- Support to recursively navigate tree instead of using static navigation structure
+- Added "--custom" option to support chosing custom navigation and updated structure to include all remaining navigation properties
+- Captures GET headers in headers.json for each api
+- Captures execution time in time.json for each api
+- Adds @redfish.copyright property to each resource; Can specify copyright with "-C `<copyright_message>`" and longform "--Copyright"
+- Updated redfishtool library to 0.9.3
+
 ## [0.9.1] - 2016-09-06
 - Initial Public Release
-- 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Copyright 2016 Distributed Management Task Force, Inc. All rights reserved.
 # redfishMockupCreator
 
 ## About
-***redfishMockupCreator*** is a python34 program that creates a redfish Mockup folder structure from a real live Redfish service.
+***redfishMockupCreator*** is a python34 program that creates a redfish Mockup folder structure from a real live Redfish service.  This folder structure can then be mounted under the Redfish-Mockup-Server tool.
 
 The program executes Redfish GET requests to the Redfish service and saves the response in a directory structure like what is used for all Redfish mockups.
 
@@ -16,21 +16,51 @@ As a result, it is a way to take a snapshot of a system
 
 ### Options
    `redfishMockupCreate  [-VhvqS] -u<user> -p<passwd> -r<rpath> [-A<auth>] [-D<directoryPath>] -d [<descriptionString>]`
-    
-       -V -- prints version and exits
-       -h -- help (gives syntax and usage)
-       -v -- verbose (can add more than 1). -v gives addl debug printouts, -vv adds execution tracing, -vvv...,-vvvv...
-       -q -- quiet (no output)
-       -S -- use https for all transactions
-       -u<user>  -- the username for authentication
-       -p<passwd>-- the password for authentication
-       -r<rpath> -- the IP and port of the remote manager:   eg 127.0.0.1:8001
-       -A<auth>  -- the authentication mechanism (same as redfishtool): None, Basic, Session (dflt)
-       -D<dirPath>  -- the directory path from program to where the mockup will be created (relative or absolute). 
-       the program does not create theh directory. you have to do that ahead of time.
-       -d<description> -- <description> is a string that is stored at the top of the mockup directory in a README file 
+   -V,          --version           -- show redfishMockupCreate version, and exit
+   -h,          --help              -- show Usage, Options
+   -v,          --verbose           -- verbose level, can repeat up to 4 times for more verbose output
+                                       -v
+   -q,          --quiet             -- quiet mode. no progress messages are displayed
+   --custom     -- custom mode. use static nav structure instead of recursive algorithm
+   -C,          --Copyright         -- Add Copyright. The specified Copyright will be added to each resource
+   -H,          --Headers           -- Headers mode. An additional headers property will be added to each resource
+   -T,          --Time              -- Time mode. Retrieval time of each GET will be captured
+   -S,          --Secure            -- use HTTPS for all gets.   otherwise HTTP is used
+   -u <user>,   --user=<usernm>     -- username used for remote redfish authentication
+   -p <passwd>, --password=<passwd> -- password used for remote redfish authentication
+   -r <rhost>,  --rhost=<rhost>     -- remote redfish service hostname or IP:port
+   -A <Auth>,   --Auth=<auth>       -- auth method ot use: None, Basic(dflt), Session
+   -D <directory>,--Dir=<directory> -- output mockup to directory path <directory>
+   -d <description> --description=<d> -- text description that is put in README. ex: -d "mockup of Contoso 1U"
 
-### Notes
+
+##  Example
+### Create a directory that is the name of the mockup you are creating
+* fyi-mockup-creator wont create the directory, if the dir doesn’t exist, it exits with error
+* fyi-also, it won’t over-write the data in an existing directory--if you want to re-run and store the mockup in the same directory, you have to remove all of the files under the dir so make the directory under mymockups
+
+`cd $HOME/mymockups && mkdir C6320mockup9`
+
+### Now run the creator
+* Assuming you downloaded the Redfish-Mockup-Creator to $HOME/redfishtools/Redfish-Mockup-Creator
+
+`cd $HOME/redfishtools/Redfish-Mockup-Creator`
+
+* Make sure you have python3.4 or later in your path
+* Set the IP address of the Redfish server you are going to get the mockup from
+    * MYC6320IP=129.168.0.9  #ex
+
+`python3.4 ./redfishMockupCreate.py –r $MYC6320IP –u root –p calvin –S –A Basic –D “$HOME/mymockups/C6320mockup9” \
+          -d “this is my mockup of a real C6320 in rack33"`
+
+     -r <ip> is the ip address of the server you are pulling the mockup from
+     -u, -p is user/password
+     -S   (it’s a capital S) tells it to use HTTPS for everything---powerEdge requires HTTPS.
+     -A Basic    says use basic auth (I think that’s the default, the man page says Session is dflt ,but just specify Basic to be sure)
+     -D <dir>   tells it the directory to put it in.---must be empty and must already exist
+     -d <descriptionString>   is a short description you can add that it appends to the READ file  at the top of the mockup.`
+
+## Notes
 * Since a real redfish service can implement any URI it wants (they don't have to start with /redfish/v1), this creates a "tall mockup".  That is, it starts creating a directory structure with everything below the IP address of the remote service---it therefore includes /redfish/v1 in the directory structure.
 
 * Initial version: 0.9.1  provides mockup tree based on redfish 1.0 schemas.

--- a/README.md
+++ b/README.md
@@ -15,24 +15,24 @@ As a result, it is a way to take a snapshot of a system
  
 
 ### Options
-   `redfishMockupCreate  [-VhvqS] -u<user> -p<passwd> -r<rpath> [-A<auth>] [-D<directoryPath>] -d [<descriptionString>]`
-   -V,          --version           -- show redfishMockupCreate version, and exit
-   -h,          --help              -- show Usage, Options
-   -v,          --verbose           -- verbose level, can repeat up to 4 times for more verbose output
-                                       -v
-   -q,          --quiet             -- quiet mode. no progress messages are displayed
-   --custom     -- custom mode. use static nav structure instead of recursive algorithm
-   -C,          --Copyright         -- Add Copyright. The specified Copyright will be added to each resource
-   -H,          --Headers           -- Headers mode. An additional headers property will be added to each resource
-   -T,          --Time              -- Time mode. Retrieval time of each GET will be captured
-   -S,          --Secure            -- use HTTPS for all gets.   otherwise HTTP is used
-   -u <user>,   --user=<usernm>     -- username used for remote redfish authentication
-   -p <passwd>, --password=<passwd> -- password used for remote redfish authentication
-   -r <rhost>,  --rhost=<rhost>     -- remote redfish service hostname or IP:port
-   -A <Auth>,   --Auth=<auth>       -- auth method ot use: None, Basic(dflt), Session
-   -D <directory>,--Dir=<directory> -- output mockup to directory path <directory>
+```
+   redfishMockupCreate  [-VhvqS] -u<user> -p<passwd> -r<rpath> [-A<auth>] [-D<directoryPath>] -d [<descriptionString>]
+   -V,          --version             -- show redfishMockupCreate version, and exit
+   -h,          --help                -- show Usage, Options
+   -v,          --verbose             -- verbose level, can repeat up to 4 times for more verbose output
+   -q,          --quiet               -- quiet mode. no progress messages are displayed
+   --custom                           -- custom mode. use static nav structure instead of recursive algorithm
+   -C <string>, --Copyright=<string>  -- Add Copyright message. The specified Copyright will be added to each resource
+   -H,          --Headers             -- Headers mode. An additional headers property will be added to each resource
+   -T,          --Time                -- Time mode. Retrieval time of each GET will be captured
+   -S,          --Secure              -- use HTTPS for all gets.   otherwise HTTP is used
+   -u <user>,   --user=<usernm>       -- username used for remote redfish authentication
+   -p <passwd>, --password=<passwd>   -- password used for remote redfish authentication
+   -r <rhost>,  --rhost=<rhost>       -- remote redfish service hostname or IP:port
+   -A <Auth>,   --Auth=<auth>         -- auth method ot use: None, Basic(dflt), Session
+   -D <directory>,--Dir=<directory>   -- output mockup to directory path <directory>
    -d <description> --description=<d> -- text description that is put in README. ex: -d "mockup of Contoso 1U"
-
+```
 
 ##  Example
 ### Create a directory that is the name of the mockup you are creating
@@ -51,7 +51,7 @@ As a result, it is a way to take a snapshot of a system
     * MYC6320IP=129.168.0.9  #ex
 
 `python3.4 ./redfishMockupCreate.py –r $MYC6320IP –u root –p calvin –S –A Basic –D “$HOME/mymockups/C6320mockup9” \
-          -d “this is my mockup of a real C6320 in rack33"`
+          -d “this is my mockup of a real C6320 in rack33" -C "Copyright 2016 Contoso.com Inc. All rights reserved."`
 
      -r <ip> is the ip address of the server you are pulling the mockup from
      -u, -p is user/password

--- a/redfishMockupCreate.py
+++ b/redfishMockupCreate.py
@@ -52,7 +52,7 @@ def displayOptions(rft):
         print("   -v,          --verbose           -- verbose level, can repeat up to 4 times for more verbose output")
         print("                                       -v ")
         print("   -q,          --quiet             -- quiet mode. no progress messages are displayed")
-        print("   -C,          --custom            -- custom mode. use static over recursive root resource discovery")
+        print("   -C,          --custom            -- custom mode. use static nav structure instead of recursive algorithm")
         print("   -S,          --Secure            -- use HTTPS for all gets.   otherwise HTTP is used")
         print("   -u <user>,   --user=<usernm>     -- username used for remote redfish authentication")
         print("   -p <passwd>, --password=<passwd> -- password used for remote redfish authentication")
@@ -103,12 +103,17 @@ def main(argv):
 
     # set default verbose level to 1.  so -v will cause verbose level to go to 2
     rft.verbose=1
+    rft.program="redfishMockupCreate"
+    rft.version="0.9.2"
+    rft.releaseDate="05/28/2017"
+    rft.secure="Never"
     
     #initialize properties used here in main
     mockDirPath=None
     mockDir=None
-    description=None
+    description=""
     rfFile="index.json"
+    custom=False
     
     try:
         opts, args = getopt.gnu_getopt(argv[1:],"VhvqSu:p:r:A:D:d:C",
@@ -145,7 +150,7 @@ def main(argv):
         elif opt in ("-q", "--quiet"):
             rft.quiet=true
         elif opt in ("-C", "--custom"):
-            rft.custom=True
+            custom=True
         elif opt in ("-A", "--Auth"):           # specify authentication type
             rft.auth=arg
             if not rft.auth in rft.authValidValues:
@@ -301,7 +306,7 @@ def main(argv):
     rft.printVerbose(1,"Start Creating resources under root service:")
 
     # If we specified "Custom" in optargs then run static discovery of resources
-    if( rft.custom is True):
+    if( custom is True):
         rft.printVerbose("Custom discovery of resources under root service specified")
 
         for rlink in rootLinks:
@@ -344,11 +349,11 @@ def recursive_call(rft,rs,rootUrl,mockDir):
     d = get_nav_and_collection_properties(rft, rs)
     if d is not None:
         for x in d:
-            rft.printVerbose(1,"   Creating resource under root service navigation property: {}".format(x))
+            rft.printVerbose(1,"   Creating resource under navigation property: {}".format(x))
             # readResourceMkdirCreateIndxFile() method will create a directory and index.json file for the resource link
             rc,r,j,d=readResourceMkdirCreateIndxFile(rft,rootUrl, mockDir, x)
             if(rc!=0):
-                rft.printErr("ERROR: got error reading root service collection member--continuing. link: {}".format(x))    
+                rft.printErr("ERROR: got error reading resource --continuing. link: {}".format(x))    
             # Recursively calling further tree nodes which will fetch data.
             recursive_call(rft,d,rootUrl,mockDir)
     else:

--- a/redfishMockupCreate.py
+++ b/redfishMockupCreate.py
@@ -485,7 +485,7 @@ def readResourceMkdirCreateIndxFile(rft, rootUrl, mockDir, link, addCopyright, a
     #Add copyright key/value pair into index.json
     if (addCopyright is not None):
         if(type(d) is dict):
-            d['@redfish.copyright'] = addCopyright
+            d['@Redfish.copyright'] = addCopyright
         else:
             rft.printErr("BUG: Expecting a dictionary for resource {} but got type: {}".format(absPath, type(d)))
     #Store resource dictionary into index.json

--- a/redfishMockupCreate.py
+++ b/redfishMockupCreate.py
@@ -378,6 +378,8 @@ def recursive_call(rft,rs,rootUrl,mockDir, addCopyright, addHeaders, addTime, ex
 def get_nav_and_collection_properties(rft,rs, exceptionList):    
     if not isinstance(rs,dict):
         return (None)
+    if "@odata.id" not in rs:
+        return (None)
     nav_list = list()
     # Seperate rule for Exception list. 
     if ( any(x in rs['@odata.id']  for x in exceptionList ) ) :

--- a/redfishMockupCreate.py
+++ b/redfishMockupCreate.py
@@ -37,10 +37,6 @@ resourceLinks={
         "EventService": ["Subscriptions"]
 }
 
-addCopyright = None
-headers = None
-time = None
-
 def displayUsage(rft,*argv,**kwargs):
         rft.printErr("  Usage:",noprog=True)
         rft.printErr("   {} [-VhvqS] -u<user> -p<passwd> -r<rhost[<port>] [-A <auth>] [-D <dir>]",prepend="  ")
@@ -121,15 +117,15 @@ def main(argv):
     rfFileHeaders="headers.json"
     rfFileTime="time.json"
     custom=False
-    addCopyright=False #TODO must this be global or change api signatures?
-    headers=False
-    time=False
+    addCopyright=None
+    addHeaders=False
+    addTime=False
     
     try:
-        opts, args = getopt.gnu_getopt(argv[1:],"VhvqSu:p:r:A:C:H:T:D:d:",
+        opts, args = getopt.gnu_getopt(argv[1:],"VhvqSHTu:p:r:A:C:D:d:",
                         ["Version", "help", "quiet", "Secure=",
                          "user=", "password=", "rhost=","Auth=",
-                         "custom", "Copyright", "Headers", "Time", "Dir=, description=]"])
+                         "custom", "Copyright=", "Headers", "Time", "Dir=, description=]"])
     except getopt.GetoptError:
         rft.printErr("Error parsing options")
         displayUsage(rft)
@@ -163,14 +159,11 @@ def main(argv):
         elif opt in ("--custom"):
             custom=True
         elif opt in ("-C", "--Copyright"):
-            global addCopyright
             addCopyright=arg
         elif opt in ("-H", "--Headers"):
-            global headers
-            headers=True
+            addHeaders=True
         elif opt in ("-T", "--Time"):
-            global time
-            time=True
+            addTime=True
         elif opt in ("-A", "--Auth"):           # specify authentication type
             rft.auth=arg
             if not rft.auth in rft.authValidValues:
@@ -335,7 +328,7 @@ def main(argv):
             if(rlink in rootRes):
                 link=rootRes[rlink]
                 rft.printVerbose(1,"   Creating resource under root service navigation property: {}".format(rlink))
-                rc,r,j,d=readResourceMkdirCreateIndxFile(rft, rootUrl, mockDir, link)
+                rc,r,j,d=readResourceMkdirCreateIndxFile(rft, rootUrl, mockDir, link, addCopyright, addHeaders, addTime)
                 if(rc!=0):
                     rft.printErr("ERROR: got error reading root service resource--continuing. link: {}".format(link))
                 resd=d
@@ -343,40 +336,40 @@ def main(argv):
                 if isCollection(resd) is True:  # (eg Systems, Chassis...)
                     for member in resd["Members"]:
                         rft.printVerbose(4,"    Collection member: {}".format(member))
-                        rc,r,j,d=readResourceMkdirCreateIndxFile(rft,rootUrl, mockDir, member)
+                        rc,r,j,d=readResourceMkdirCreateIndxFile(rft,rootUrl, mockDir, member, addCopyright, addHeaders, addTime)
                         if(rc!=0):
                             rft.printErr("ERROR: got error reading root service collection member--continuing. link: {}".format(member))
                         memberd=d
                         sublinklist=resourceLinks[rlink]
-                        rc,r,j,d=addSecondLevelResource(rft, rootUrl,mockDir,  sublinklist, memberd)
+                        rc,r,j,d=addSecondLevelResource(rft, rootUrl,mockDir,  sublinklist, memberd, addHeaders, addTime, member)
                         if(rc!=0):
                             rft.printErr("ERROR: Error processing 2nd level resource (8)--continuing. link:{}".format(member))
                 else:   # its not a collection. (eg accountService) do the 2nd level resources now
                     sublinklist=resourceLinks[rlink]
-                    rc,r,j,d=addSecondLevelResource(rft, rootUrl, mockDir, sublinklist, resd)
+                    rc,r,j,d=addSecondLevelResource(rft, rootUrl, mockDir, sublinklist, resd, addHeaders, addTime, member)
                     if(rc!=0):
                         rft.printErr("ERROR: Error processing 2nd level resource (9) --continuing")
     else:
         # Starting recursive call.
-        recursive_call(rft,rootv1data,rootUrl,mockDir)
+        recursive_call(rft,rootv1data,rootUrl,mockDir, addCopyright, addHeaders, addTime)
 
     rft.printVerbose(1," {} Completed creating mockup".format(rft.program))
     sys.exit(0)
 
 
-def recursive_call(rft,rs,rootUrl,mockDir):
+def recursive_call(rft,rs,rootUrl,mockDir, addCopyright, addHeaders, addTime):
     # get_nav_and_collection_properties() method will go and fetch any nav or collection properties if present.
     # If none returns None. Indicating that there are no further down navigations.
     d = get_nav_and_collection_properties(rft, rs)
     if d is not None:
         for x in d:
             rft.printVerbose(1,"   Creating resource under navigation property: {}".format(x))
-            # readResourceMkdirCreateIndxFile() method will create a directory and index.json file for the resource link
-            rc,r,j,d=readResourceMkdirCreateIndxFile(rft,rootUrl, mockDir, x)
+            # readResourceMkdirCreateIndxFile(addCopyright, addHeaders, addTime, ) method will create a directory and index.json file for the resource link
+            rc,r,j,d=readResourceMkdirCreateIndxFile(rft,rootUrl, mockDir, x, addCopyright, addHeaders, addTime)
             if(rc!=0):
                 rft.printErr("ERROR: got error reading resource --continuing. link: {}".format(x))    
             # Recursively calling further tree nodes which will fetch data.
-            recursive_call(rft,d,rootUrl,mockDir)
+            recursive_call(rft,d,rootUrl,mockDir, addCopyright, addHeaders, addTime)
     else:
         return (None)
 
@@ -420,12 +413,12 @@ def rfMakeDir(rft, dirPath):
 
 
 
-def readResourceMkdirCreateIndxFile(rft, rootUrl, mockDir, link, jsonData=True):
+def readResourceMkdirCreateIndxFile(rft, rootUrl, mockDir, link, addCopyright, addHeaders, addTime, jsonData=True):
     #print("building resource tree for link: {}".format(link))
     if not "@odata.id" in link:
         rft.printErr("ERROR:readResourceMkdirCreateIndxFile: no @odata.id property in link: {}".format(link))
         return(5,None,False, None)
-    
+
     absPath=link["@odata.id"]
     if(absPath[0]=='/'):
         relPath=absPath[1:]
@@ -445,41 +438,43 @@ def readResourceMkdirCreateIndxFile(rft, rootUrl, mockDir, link, jsonData=True):
 
 
     #Store headers into the headers.json
-    hdrsFilePath=os.path.join(dirPath,"headers.json")
-    with open( hdrsFilePath, 'w', encoding='utf-8' ) as hf:
-        #TODO Q how to understand types/dicts better
-        dictHeader = dict(r.headers)
-        headerFileData = {"GET" : dictHeader}
-        json.dump(headerFileData, hf, indent=4)
+    if (addHeaders is True):
+        hdrsFilePath=os.path.join(dirPath,"headers.json")
+        with open( hdrsFilePath, 'w', encoding='utf-8' ) as hf:
+            #TODO Q how to understand types/dicts better
+            dictHeader = dict(r.headers)
+            headerFileData = {"GET" : dictHeader}
+            json.dump(headerFileData, hf, indent=4)
 
-    #TODO Josh add new option -T or --Time time.json
-    timeFilePath=os.path.join(dirPath,"time.json")
-    with open( timeFilePath, 'w', encoding='utf-8' ) as tf:
-        elapsedTime = '{0:.2f}'.format(r.elapsed.total_seconds())
-        timeFileData = {"GET_Time": elapsedTime}
-        json.dump(timeFileData, tf, indent=4) 
+    #Store elapsed response time into time.json
+    if (addTime is True):
+        timeFilePath=os.path.join(dirPath,"time.json")
+        with open( timeFilePath, 'w', encoding='utf-8' ) as tf:
+            elapsedTime = '{0:.2f}'.format(r.elapsed.total_seconds())
+            timeFileData = {"GET_Time": elapsedTime}
+            json.dump(timeFileData, tf, indent=4)
 
-    #Add copyright key/value pair 
+    #Add copyright key/value pair into index.json
     if (addCopyright is not None):
         d['@redfish.copyright'] = addCopyright
     filePath=os.path.join(dirPath,"index.json")
     with open( filePath, 'w', encoding='utf-8' ) as f:
         json.dump(d, f, indent=4) #TODO change to .json?
-        
+
     return(rc, r, j, d )
 
 
 
 
 # sublinklist=resourceLinks[rlink]
-def addSecondLevelResource(rft, rootUrl, mockDir, sublinklist, resd):
+def addSecondLevelResource(rft, rootUrl, mockDir, sublinklist, resd, addHeaders, addTime, member):
     if( len(sublinklist)==0 ):
         return(0,None,False,None)
     for rlink2 in sublinklist:   #(ex Processors, Power)
         if( rlink2 in resd):
             link2=resd[rlink2]
             rft.printVerbose(4,"        Creating sub-property: {}".format(rlink2))
-            rc,r,j,d=readResourceMkdirCreateIndxFile(rft,rootUrl, mockDir, link2,jsonData=True)
+            rc,r,j,d=readResourceMkdirCreateIndxFile(rft,rootUrl, mockDir, link2, addCopyright, addHeaders, addTime, jsonData=True)
             if(rc!=0):
                 rft.printErr("ERROR: got error reading 2nd level resource--continuing. link: {}".format(link2))
                 return(rc,r,j,d)
@@ -488,7 +483,7 @@ def addSecondLevelResource(rft, rootUrl, mockDir, sublinklist, resd):
             if isCollection(resd2) is True:  #ex Processors, get /1, /2
                 for member2 in resd2["Members"]:
                     rft.printVerbose(4,"          Creating 2nd-level Collection member: {}".format(member2))
-                    rc,r,j,d=readResourceMkdirCreateIndxFile(rft,rootUrl,mockDir, member2,jsonData=True)
+                    rc,r,j,d=readResourceMkdirCreateIndxFile(rft, rootUrl, mockDir, member2, addCopyright, addHeaders, addTime, jsonData=True)
                     resd3=d
                     if(rc!=0):
                         rft.printErr("ERROR: got error reading 2nd level collection member--continuing. link: {}".format(member2))
@@ -499,18 +494,18 @@ def addSecondLevelResource(rft, rootUrl, mockDir, sublinklist, resd):
                         if( "Entries" in resd3):
                             entriesLink=resd3["Entries"]
                             rft.printVerbose(2,"               Creating LogService Entries (Expanded Collection): {}".format(member2))
-                            rc,r,j,d=readResourceMkdirCreateIndxFile(rft,rootUrl,mockDir, entriesLink,jsonData=False)
+                            rc,r,j,d=readResourceMkdirCreateIndxFile(rft, rootUrl, mockDir, entriesLink, addCopyright, addHeaders, addTime, jsonData=False)
                             if(rc!=0):
                                 rft.printErr("ERROR: got error reading logService Entries collection resource--continuing. link: {}".format(entriesLink))
         else:
             rft.printVerbose(2,"       No sub-properties in resource: {}")
             return(0,None,False,None)
-    
+
     return(rc,r,j,d)
 
 
 
-                                     
+
 
 def isCollection(resource):
     if "Members" in resource:

--- a/redfishMockupCreate.py
+++ b/redfishMockupCreate.py
@@ -232,7 +232,7 @@ def main(argv):
         readf.write("Created: {}\n".format(rfdatetime))
         readf.write("rhost:  {}\n".format(rft.rhost))
         readf.write("Description: {}\n".format(description))
-        readf.write("Commandline: {} {}\n".format('python34', ' '.join(argv)))
+        readf.write("Commandline: {} {}\n".format('python3.4', ' '.join(argv)))
     if os.path.isfile(readmeFile) is False:
         rft.printErr("ERROR: cant create README file in directory. aborting")
         sys.exit(1)
@@ -346,7 +346,7 @@ def main(argv):
                             rft.printErr("ERROR: Error processing 2nd level resource (8)--continuing. link:{}".format(member))
                 else:   # its not a collection. (eg accountService) do the 2nd level resources now
                     sublinklist=resourceLinks[rlink]
-                    rc,r,j,d=addSecondLevelResource(rft, rootUrl, mockDir, sublinklist, resd, addHeaders, addTime, member)
+                    rc,r,j,d=addSecondLevelResource(rft, rootUrl, mockDir, sublinklist, memberd, addCopyright, addHeaders, addTime)
                     if(rc!=0):
                         rft.printErr("ERROR: Error processing 2nd level resource (9) --continuing")
     else:

--- a/redfishMockupCreate.py
+++ b/redfishMockupCreate.py
@@ -443,9 +443,6 @@ def readResourceMkdirCreateIndxFile(rft, rootUrl, mockDir, link, jsonData=True):
         rft.printErr("ERROR:readResourceMkdirCreateIndxFile: for link:{}, path:{}, cant create directory: {}. aborting".format(link,absPath,dirPath))
         return(5,r,False, None)
 
-    #Add copyright key/value pair 
-    if (addCopyright is not None):
-        d['@redfish.copyright'] = addCopyright
 
     #Store headers into the headers.json
     hdrsFilePath=os.path.join(dirPath,"headers.json")
@@ -453,21 +450,21 @@ def readResourceMkdirCreateIndxFile(rft, rootUrl, mockDir, link, jsonData=True):
         #TODO Q how to understand types/dicts better
         dictHeader = dict(r.headers)
         headerFileData = {"GET" : dictHeader}
-        json.dump(headerFileData, hf)
+        json.dump(headerFileData, hf, indent=4)
 
     #TODO Josh add new option -T or --Time time.json
     timeFilePath=os.path.join(dirPath,"time.json")
     with open( timeFilePath, 'w', encoding='utf-8' ) as tf:
         elapsedTime = '{0:.2f}'.format(r.elapsed.total_seconds())
         timeFileData = {"GET_Time": elapsedTime}
-        json.dump(timeFileData, tf) 
+        json.dump(timeFileData, tf, indent=4) 
 
-
+    #Add copyright key/value pair 
+    if (addCopyright is not None):
+        d['@redfish.copyright'] = addCopyright
     filePath=os.path.join(dirPath,"index.json")
-
     with open( filePath, 'w', encoding='utf-8' ) as f:
-        #f.write(r.text) #TODO change to .json?
-        json.dump(d, f) #TODO change to .json?
+        json.dump(d, f, indent=4) #TODO change to .json?
         
     return(rc, r, j, d )
 

--- a/redfishtoollib/ServiceRoot.py
+++ b/redfishtoollib/ServiceRoot.py
@@ -1,9 +1,9 @@
 # Copyright Notice:
 # Copyright 2016 Distributed Management Task Force, Inc. All rights reserved.
-# License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/Redfish-Mockup-Creator/LICENSE.md
+# License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/Redfishtool/LICENSE.md
 
 # redfishtool: ServiceRoot.py
-# v0.9.1 with transport import commented out
+# v0.9.2
 # contains serviceRoot related subCommands and access functions
 # Class RfServiceRoot
 #  - getServiceRoot   GET /redfish/v1
@@ -36,7 +36,7 @@ class RfServiceRoot:
         if cmdTop is True:  prop=rft.prop
 
         # get root service.  if -P prop, showproperty
-        rc,r,j,d=rft.rftSendRecvRequest(rft.UNAUTHENTICATED_API, 'GET', r.url, relPath=rft.rootPath,prop=prop)
+        rc,r,j,d=rft.rftSendRecvRequest(rft.UNAUTHENTICATED_API, 'GET', rft.rootUri, relPath=rft.rootPath,prop=prop)
 
         #save the rootService response.  The transport may need it later to get link to session and login
         rft.rootResponseDict=d
@@ -59,8 +59,8 @@ class RfServiceRoot:
 
         #calculate relative path = rootPath / odata
         rpath=urljoin(rft.rootPath, "odata")
-
-        rc,r,j,d=rft.rftSendRecvRequest(rft.UNAUTHENTICATED_API, 'GET', r.url, relPath=rpath)
+        
+        rc,r,j,d=rft.rftSendRecvRequest(rft.UNAUTHENTICATED_API, 'GET', rft.rootUri, relPath=rpath)
         if(rc==0 ):
             rft.printVerbose(1," Odata Service Document:",skip1=True, printV12=cmdTop)
         return(rc,r,j,d)
@@ -85,7 +85,7 @@ class RfServiceRoot:
         hdrs = {"Accept": "application/xml", "OData-Version": "4.0" }
 
 
-        rc,r,j,d=rft.rftSendRecvRequest(rft.UNAUTHENTICATED_API, 'GET', r.url, relPath=rpath, jsonData=False, headersInput=hdrs )
+        rc,r,j,d=rft.rftSendRecvRequest(rft.UNAUTHENTICATED_API, 'GET', rft.rootUri, relPath=rpath, jsonData=False, headersInput=hdrs )
         if(rc==0):
             rft.printVerbose(1," Odata Metadata Document:",skip1=True,printV12=cmdTop)
         return(rc,r,j,d)
@@ -94,9 +94,5 @@ class RfServiceRoot:
 TODO:
 1.
 
-CHANGELOG:
-v0.9 --initial
-v0.9.1 -- getOdataMetadataDocument(): changed hdrs to Accept: application/xml,  OData-Version: 4.0
-          old value was content-type application/xml.  we want the response xml, so it should be Accept
 
 '''

--- a/redfishtoollib/ServiceRoot.py
+++ b/redfishtoollib/ServiceRoot.py
@@ -10,7 +10,6 @@
 #  - getOdataServiceDocument    GET /redfish/v1/odata
 #  - getOdataMetadataDocument   GET /redfish/v1/$metadata
 #
-#from   .redfishtoolTransport import RfTransport
 import requests
 import json
 from urllib.parse import urljoin, urlparse, urlunparse

--- a/redfishtoollib/redfishtoolTransport.py
+++ b/redfishtoollib/redfishtoolTransport.py
@@ -84,6 +84,7 @@ class RfTransport():
         self.quiet=False
         self.user=""
         self.password=""
+        self.custom=False
         self.rhost=None
         self.token=None
         self.protocolVer="Latest"

--- a/redfishtoollib/redfishtoolTransport.py
+++ b/redfishtoollib/redfishtoolTransport.py
@@ -3,7 +3,7 @@
 # License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/Redfishtool/LICENSE.md
 
 # redfishtool:  redfishtoolTransport.py
-# v0.9.2
+# v0.9.3
 # Contents:
 # 1. Class RfSessionAuth --  holds auto-created session Auth info.  'requests' calls to get credentials
 # 2. Class RfTransport -- has the generic functions to send/receive http requests, generic print functions, etc  
@@ -41,8 +41,7 @@ import socket
 import time
 from urllib.parse import urljoin, urlparse, urlunparse
 from requests.auth import HTTPBasicAuth, AuthBase
-#import urllib3
-from    .ServiceRoot import RfServiceRoot
+from .ServiceRoot import RfServiceRoot
 
 
 class RfSessionAuth(AuthBase):
@@ -55,17 +54,12 @@ class RfSessionAuth(AuthBase):
         #print("Call SESSION AUTH")
         return(r)
 
-#xxx
-#redfishtoolTransport.py:        self.program="RMredfishtool"              # program name (in case we want to change it (_RM_)
-#redfishtoolTransport.py:        self.rhost="127.0.0.1"   # (_RM_)
-#xxx
-
 class RfTransport():
     def __init__(self):
         # constant parameters-- these dont change and are not updated
-        self.program="RMredfishtool"              # program name (in case we want to change it (_xgRM_)
-        self.version="0.9.2"                    # this redfishtool version
-        self.releaseDate="12/05/2016"           # release date for this version of redfishtool
+        self.program="redfishtool"              # program name (in case we want to change it)
+        self.version="0.9.3"                    # this redfishtool version
+        self.releaseDate="4/17/2017"            # release date for this version of redfishtool
         self.downloadFrom="https://github.com/DMTF/Redfishtool" # where to find redfishtool
         self.magic="12345"                      # used for debug to test for a known parameter in this object
         self.UNAUTHENTICATED_API=1              # unauthenticated API that doesn't send credentials in body data
@@ -74,7 +68,7 @@ class RfTransport():
         self.UNAUTHENTICATED_WITH_CREDENTIALS_API=4 # session login (unauthenticated) but sends credentials
         self.authValidValues=["None", "Basic", "Session"]
         self.secureValidValues=["Never", "IfSendingCredentials", "IfLoginOrAuthenticatedApi", "Always"]
-        self.supportedVersions=["v0","v1"]      # list of RedfishProtocolVersions that this program supports
+        self.supportedVersions=["v1"]      # list of RedfishProtocolVersions that this program supports
         self.MaxNextLinks=10                # max number of requests allowed with NextLink
         self.dfltPatchPostPutHdrs = {'OData-Version': '4.0', 'Content-Type': 'application/json', 'Accept': 'application/json'  }
         self.dfltGetDeleteHeadHdrs = {'Accept': 'application/json', 'OData-Version': '4.0' }
@@ -88,7 +82,7 @@ class RfTransport():
         self.quiet=False
         self.user=""
         self.password=""
-        self.rhost="127.0.0.1:5001" # (_xgRM_)
+        self.rhost=None
         self.token=None
         self.protocolVer="v1"
         self.auth="Basic"  # or "Session" using Basic as default now
@@ -122,8 +116,7 @@ class RfTransport():
         
         self.Link=None   # -L <Link> or --Link=<link>
         self.configFile=""      
-        #self.secure="IfLoginOrAuthenticatedApi" #Never
-        self.secure="Never" # (_xgRM_) RM doesn't require
+        self.secure="IfLoginOrAuthenticatedApi" #Never
         self.waitTime=3
         self.waitNum=1
         self.headers=None
@@ -151,6 +144,9 @@ class RfTransport():
         self.sessionLink=None
         self.authToken=None
         self.cleanupOnExit=True
+
+        # measured execution time
+        self.elapsed=None
 
         requests.packages.urllib3.disable_warnings()
 
@@ -243,7 +239,10 @@ class RfTransport():
         for attempt in range(0,rft.waitNum):
             try:
                 rft.printVerbose(3,"Transport:getVersions: GET {}".format(url))
+                t1=time.time()
                 r = requests.get(url, headers=hdrs, verify=False, timeout=(rft.waitTime,rft.timeout))  # GET ^/redfish
+                t2=time.time()
+                rft.elapsed = t2 - t1
                 # print request headers
                 rft.printStatus(3,r=r,authMsg=None)
 
@@ -480,8 +479,11 @@ class RfTransport():
         for attempt in range(0,rft.MaxNextLinks):
             try:
                 rft.printVerbose(3,"Transport:SendRecv:    {} {}".format(method,url))
+                t1=time.time()
                 r = requests.request(method, url, headers=hdrs, auth=authType, verify=verify, data=reqData,
                                      timeout=(rft.waitTime,rft.timeout),**kwargs)  # GET ^/redfish
+                t2=time.time()
+                rft.elapsed = t2 - t1
                 # print request headers
                 rft.printStatus(3,r=r,authMsg=authMsg)
 
@@ -749,7 +751,7 @@ class RfTransport():
             print("#STATUS: Last Response: r.status_code: {}".format(r.status_code))
         elif( (s==2 ) and (self.status >= s ) and (r is not None) ):
             print("#STATUS: Last Response: r.url: {}".format(r.url))
-            print("#STATUS: Last Response: r.elapsed(responseTime): {0:.2f} sec".format(r.elapsed.total_seconds()))
+            print("#STATUS: Last Response: r.elapsed(responseTime): {0:.2f} sec".format(self.elapsed))
         elif( (s==3 ) and (self.status >= s ) and (r is not None) ):
             if( addSessionLoginInfo is True):
                 print("#____AUTH_TOKEN:  {}".format(self.authToken))
@@ -761,7 +763,7 @@ class RfTransport():
                 print("#__Request AuthType: {}".format(authMsg))
                 print("#__Request Data: {}".format(r.request.body))
                 print("#__Response.status_code: {},         r.url: {}".format(r.status_code,r.url))
-                print("#__Response.elapsed(responseTime): {0:.2f} sec".format(r.elapsed.total_seconds()))
+                print("#__Response.elapsed(responseTime): {0:.2f} sec".format(self.elapsed))
         elif( (s==4 ) and (self.status >= s ) and (r is not None) ):
             print("#__Response.Headers: {}".format(r.headers))
         elif( (s==5 ) and (self.status >= s )  ):
@@ -1062,7 +1064,7 @@ class RfTransport():
 
 
     # this is the generic patch routing used by Systems patch, Chassis patch, etc
-    def patchResource(self, rft, r, patchData ):
+    def patchResource(self, rft, r, patchData, getResponseAfterPatch=True ):
         if( patchData is None ):
             rft.printErr("Transport:Patch: patchData=None")
             return(4,None,False,None)
@@ -1099,9 +1101,14 @@ class RfTransport():
                                         headersInput=patchHeaders, reqData=reqPatchData)
         # if response was good but no data retured (status_Code=204), then do another GET to get the response
         if(rc==0):
-            if(r.status_code==204):  #no data returned, get the response
-                rc,r,j,d=rft.rftSendRecvRequest(rft.AUTHENTICATED_API, 'GET', r.url )
-                if( rc != 0):  return(rc,r,False,None)
+            if(r.status_code==204):  #no data returned, get the response   
+                # if the getResponseAfterPatch was set False, dont get a response
+                # this is used by change password to not execute after changing password since the
+                if getResponseAfterPatch is True:
+                    rc,r,j,d=rft.rftSendRecvRequest(rft.AUTHENTICATED_API, 'GET', r.url )
+                    if( rc != 0):  return(rc,r,False,None)
+                else:
+                    return(rc,r,False,None)
             #now check if status_code=200, but the content is a message--not a resource representation
             #some 1.0 implementations are returning 200 with message OK
             #thus, we need to do another GET


### PR DESCRIPTION
* Support to recursively navigate tree instead of using static navigation structure
* Added "--custom" option to support choosing custom navigation and updated structure to include all remaining navigation properties
* Captures GET headers in headers.json for each api
* Captures execution time in time.json for each api
* Adds @redfish.copyright property to each resource; Can specify copyright with "-C <copyright_message>" and long form "--Copyright"
* Updated redfishtool library to 0.9.3