### PR TITLE
Fix issues #10 and #11

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ As a result, it is a way to take a snapshot of a system
 ##  Python Requirement
 **The `requests` package is required.**
 
-- On windoes, navigate to your Python folder via CMD.
+- On Windows, navigate to your Python folder via CMD.
 
 	`cd C:\Python36\`
 - run the command line

--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ As a result, it is a way to take a snapshot of a system
    -d <description> --description=<d> -- text description that is put in README. ex: -d "mockup of Contoso 1U"
 ```
 
+##  Python Requirement
+**The `requests` package is required.**
+
+- On windoes, navigate to your Python folder via CMD.
+
+	`cd C:\Python36\`
+- run the command line
+
+    `python -m pip install requests`
+
 ##  Example
 ### Create a directory that is the name of the mockup you are creating
 * fyi-mockup-creator wont create the directory, if the dir doesn’t exist, it exits with error

--- a/redfishMockupCreate.py
+++ b/redfishMockupCreate.py
@@ -70,6 +70,7 @@ def displayOptions(rft):
 
 def addHeaderFile(addHeaders, r, dirPath):
 #Store headers into the headers.json
+    rc = 0
     if (addHeaders is True):
         hdrsFilePath = os.path.join(dirPath, "headers.json")
         with open(hdrsFilePath, 'w', encoding='utf-8') as hf:
@@ -80,6 +81,7 @@ def addHeaderFile(addHeaders, r, dirPath):
 
 
 def addTimeFile(addTime, addHeaders, rft, r, dirPath):
+    rc = 0
     if (addTime is True):
         timeFilePath = os.path.join(dirPath, "time.json")
         with open(timeFilePath, 'w', encoding='utf-8') as tf:
@@ -137,6 +139,7 @@ def main(argv):
     rft.timeout=20
 
     #initialize properties used here in main
+    absPath=None
     mockDirPath=None
     mockDir=None
     defaultDir="rfMockUpDfltDir"


### PR DESCRIPTION
I found several issues in using the Mockup Creator.
1) I needed to import ‘requests’
On Windows, I found navigating to my Python folder via CMD worked
cd C:\Python36\
and then running the command line:
python -m pip install requests

2) In redfishMockupCreate.py there were several instances where
variables were used before initialization resulting in program halt.
In Main, I added:
absPath=None
In addHeaderFile, I added:
rc=0
In addTimeFile, I added:
rc=0