### PR TITLE
Fix parseOdataType() to allow for no version component

### DIFF
--- a/redfishtoollib/redfishtoolTransport.py
+++ b/redfishtoollib/redfishtoolTransport.py
@@ -1133,11 +1133,20 @@ class RfTransport():
         odataTypeMatch = re.compile('^#([a-zA-Z0-9]*)\.([a-zA-Z0-9\._]*)\.([a-zA-Z0-9]*)$')  
         resourceMatch = re.match(odataTypeMatch, resourceOdataType)
         if(resourceMatch is None):
-            rft.printErr("Transport:parseOdataType: Error parsing @odata.type")
-            return(None,None,None)
-        namespace=resourceMatch.group(1)
-        version=resourceMatch.group(2)
-        resourceType=resourceMatch.group(3)
+            # try with no version component
+            odataTypeMatch = re.compile('^#([a-zA-Z0-9]*)\.([a-zA-Z0-9]*)$')
+            resourceMatch = re.match(odataTypeMatch, resourceOdataType)
+            if (resourceMatch is None):
+                rft.printErr("Transport:parseOdataType: Error parsing @odata.type")
+                return(None,None,None)
+            else:
+                namespace = resourceMatch.group(1)
+                version = None
+                resourceType = resourceMatch.group(2)
+        else:
+            namespace=resourceMatch.group(1)
+            version=resourceMatch.group(2)
+            resourceType=resourceMatch.group(3)
     
         return(namespace, version, resourceType)
 


### PR DESCRIPTION
Log of test program before fix:

```
$ python3 test_fix.py 
Parsing {'@odata.type': '#SessionService.v1_0_2.SessionService'}
ns = SessionService, ver = v1_0_2, type = SessionService

Parsing {'@odata.type': '#LogServiceCollection.LogServiceCollection'}
   redfishtool: Transport:parseOdataType: Error parsing @odata.type
ns = None, ver = None, type = None

$ 
```

Log of test program after fix:

```
$ python3 test_fix.py 
Parsing {'@odata.type': '#SessionService.v1_0_2.SessionService'}
ns = SessionService, ver = v1_0_2, type = SessionService

Parsing {'@odata.type': '#LogServiceCollection.LogServiceCollection'}
ns = LogServiceCollection, ver = None, type = LogServiceCollection

$ 
```

Fixes #15
