### PR TITLE
Allow tool to continue if /redfish verion URI is missing

### DIFF
--- a/redfishtoollib/redfishtoolTransport.py
+++ b/redfishtoollib/redfishtoolTransport.py
@@ -287,7 +287,7 @@ class RfTransport():
                 rft.printStatusErr4xx(r.status_code)
             else:
                 rft.printErr("Transport Error. No response")
-            return(5,None,False,None)
+            return(5,r,False,None)
         
         #print the response status (-ssss)
         rft.printStatus(4,r=r)
@@ -602,7 +602,7 @@ class RfTransport():
             return(0,None,False,None)
         rc,r,j,d=rft.getVersionsAndSetRootPath(rft, forceCheckProtocolVer=True)
         if(rc != 0):
-            return(rc,None,False,None)
+            return(rc,r,False,None)
 
         # note that getVersionAndSetRootPath() returns the versions data as d,
         #  so there is no need to call GET /redfish again.  we have it at rft.versionsDict


### PR DESCRIPTION
If the /redfish version URI is not present on the service, report the error,  but then proceed assuming version v1.

The reported error looks like this:

> ERROR: Cannot get Redfish service version from URI /redfish (status 404). Assuming default version.

I also verified that the tool reports an error and continues with mockup creation if /redfish/v1/$metadata or /redfish/v1/odata are not present. So no changes needed for those URIs.

Fixes #42 