### PR TITLE
Fix NoneType Attribute error if the connection fails due to a timeout.

### DIFF
--- a/redfishMockupCreate.py
+++ b/redfishMockupCreate.py
@@ -277,9 +277,14 @@ def main(argv):
     # verify we can talk to the rhost
     rc, r, j, d = rft.getVersions(rft, cmdTop=True)
     if(rc != 0):
+        if r:
+            status_code = r.status_code
+        else:
+            status_code = "unknown"
+
         rft.printErr(
             "ERROR: Cannot get Redfish service version from URI /redfish (status {}). Assuming default version."
-            .format(r.status_code))
+            .format(status_code))
         rft.rootPath = urljoin("/redfish/", (rft.protocolVer + "/"))
         d = {"v1": "/redfish/v1/"}
         rf_version = json.dumps(d)


### PR DESCRIPTION
Fixes the following Attribute error thrown if the connection setup times out.

```
$ python ./redfishMockupCreate.py  -u root -p calvin -r 10.10.1.1 -D mocks/ -vvvv -S
   redfishMockupCreate: Transport: Cant connect to remote redfish service. Aborting command
   redfishMockupCreate: Transport Error. No response
Traceback (most recent call last):
  File "./redfishMockupCreate.py", line 820, in <module>
    main(sys.argv)
  File "./redfishMockupCreate.py", line 282, in main
    .format(r.status_code))
AttributeError: 'NoneType' object has no attribute 'status_code'
```