### PR TITLE
Made change to allow for the scheme to be included in the 'rhost' argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ usage: redfishMockupCreate.py [-h] --user USER --password PASSWORD --rhost
                               [--Copyright COPYRIGHT]
                               [--description DESCRIPTION] [--quiet]
 
-A tool to walk a Redfish a service and create a mockup from all resources
+A tool to walk a Redfish service and create a mockup from all resources
 
 required arguments:
   --user USER, -u USER  The user name for authentication

--- a/README.md
+++ b/README.md
@@ -38,25 +38,27 @@ required arguments:
 
 optional arguments:
   -h, --help            show this help message and exit
+  --Dir DIR, -D DIR     Output directory for the mockup; defaults to
+                        'rfMockUpDfltDir'
   --Secure, -S          Use HTTPS for all operations
   --Auth {None,Basic,Session}, -A {None,Basic,Session}
                         Authentication mode
   --Headers, -H         Captures the response headers in the mockup
   --Time, -T            Capture the time of each GET in the mockup
-  --Dir DIR, -D DIR     Output directory for the mockup
   --Copyright COPYRIGHT, -C COPYRIGHT
                         Copyright string to add to each resource
   --description DESCRIPTION, -d DESCRIPTION
                         Mockup description to add to the output readme file
   --quiet, -q           Quiet mode; progress messages suppressed
   --trace, -trace       Enable tracing; creates the file rf-mockup-create.log
-                        to capture Redfish traces with the service
+                        in the output directory to capture Redfish traces with
+                        the service
   --maxlogentries MAXLOGENTRIES, -maxlogentries MAXLOGENTRIES
                         The maximum number of log entries to collect in each
                         log service
 ```
 
-### Description
+Example: `python redfishMockupCreate.py -u root -p root -r 192.168.1.100 -S -D /output`
 
 The tool will log into the service specified by the *rhost* argument using the credentials provided by the *user* and *password* arguments.
 It will then walk the service to find all resources and place each resource in directory specified by the *Dir* argument.
@@ -65,13 +67,7 @@ For every resource found, it will create an "index.json" file in the output dire
 If the *Headers* argument is specified, it will save the response headers for each resource in a "headers.json" file.
 If the *Time* argument is specified, it will save the time elapsed for each resource in a "time.json" file. 
 
-### Native system example
-
-```bash
-python redfishMockupCreate.py -u root -p root -r 192.168.1.100 -S -D /home/user/redfish-mockup
-```
-
-### Docker container example
+## Docker container example
 
 To run as a Docker container, use one of these actions to pull or build the container:
 

--- a/redfishMockupCreate.py
+++ b/redfishMockupCreate.py
@@ -38,7 +38,7 @@ def main():
     """
 
     # Get the input arguments
-    argget = argparse.ArgumentParser( description = "A tool to walk a Redfish a service and create a mockup from all resources" )
+    argget = argparse.ArgumentParser( description = "A tool to walk a Redfish service and create a mockup from all resources" )
     argget.add_argument( "--user", "-u", type = str, required = True, help = "The user name for authentication" )
     argget.add_argument( "--password", "-p",  type = str, required = True, help = "The password for authentication" )
     argget.add_argument( "--rhost", "-r", type = str, required = True, help = "The IP address (and port) of the Redfish service" )

--- a/redfishMockupCreate.py
+++ b/redfishMockupCreate.py
@@ -42,11 +42,11 @@ def main():
     argget.add_argument( "--user", "-u", type = str, required = True, help = "The user name for authentication" )
     argget.add_argument( "--password", "-p",  type = str, required = True, help = "The password for authentication" )
     argget.add_argument( "--rhost", "-r", type = str, required = True, help = "The IP address (and port) of the Redfish service" )
+    argget.add_argument( "--Dir", "-D", type = str, help = "Output directory for the mockup; defaults to 'rfMockUpDfltDir'", default = "rfMockUpDfltDir" )
     argget.add_argument( "--Secure", "-S", action = "store_true", help = "Use HTTPS for all operations" )
     argget.add_argument( "--Auth", "-A", type = str, help = "Authentication mode", choices = [ "None", "Basic", "Session" ], default = "Session" )
     argget.add_argument( "--Headers", "-H", action = "store_true", help = "Captures the response headers in the mockup" )
     argget.add_argument( "--Time", "-T", action = "store_true", help = "Capture the time of each GET in the mockup" )
-    argget.add_argument( "--Dir", "-D", type = str, help = "Output directory for the mockup", default = "rfMockUpDfltDir" )
     argget.add_argument( "--Copyright", "-C", type = str, help = "Copyright string to add to each resource", default = None )
     argget.add_argument( "--description", "-d", type = str, help = "Mockup description to add to the output readme file", default = "" )
     argget.add_argument( "--quiet", "-q", action = "store_true", help = "Quiet mode; progress messages suppressed" )
@@ -63,10 +63,11 @@ def main():
 
     # Build the base URL for the service
     # More backwards compatibility
-    if args.Secure:
-        args.rhost = "https://{}".format( args.rhost )
-    else:
-        args.rhost = "http://{}".format( args.rhost )
+    if "://" not in args.rhost:
+        if args.Secure:
+            args.rhost = "https://{}".format( args.rhost )
+        else:
+            args.rhost = "http://{}".format( args.rhost )
 
     # Set up the output
     if not os.path.isdir( args.Dir ):


### PR DESCRIPTION
Other tools allow for the form "-r https://192.168.1.1"; this still accepts a simple IP address.

Also cleaned the readme up a bit to better direct the user to an example.