### PR TITLE
Added 'forcefolderrename' argument to replace characters that are disallowed in Windows folder names with underscores

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ optional arguments:
   --maxlogentries MAXLOGENTRIES, -maxlogentries MAXLOGENTRIES
                         The maximum number of log entries to collect in each
                         log service
+  --forcefolderrename, -forcefolderrename
+                        Indicates if URIs containing characters that are
+                        disallowed in Windows folder names are renamed to
+                        replace the characters with underscores
 ```
 
 Example: `python redfishMockupCreate.py -u root -p root -r 192.168.1.100 -S -D /output`
@@ -66,6 +70,11 @@ If *Dir* is not specified, the output will be "rfMockUpDfltDir".
 For every resource found, it will create an "index.json" file in the output directory.
 If the *Headers* argument is specified, it will save the response headers for each resource in a "headers.json" file.
 If the *Time* argument is specified, it will save the time elapsed for each resource in a "time.json" file. 
+
+Some implementations use URIs that contain characters that are disallowed in Windows folder names.
+The tool attempts to discover the OS to determine if these characters should be replaced by underscore characters.
+However, in some situations, such as a Docker container running under Windows, it's not possible for the tool to detect this condition.
+The *forcefolderrename* argument can be used in these cases to perform this replacement regardless of the detected OS.
 
 ## Docker container example
 

--- a/redfishMockupCreate.py
+++ b/redfishMockupCreate.py
@@ -52,6 +52,7 @@ def main():
     argget.add_argument( "--quiet", "-q", action = "store_true", help = "Quiet mode; progress messages suppressed" )
     argget.add_argument( "--trace", "-trace", action = "store_true", help = "Enable tracing; creates the file rf-mockup-create.log in the output directory to capture Redfish traces with the service" )
     argget.add_argument( "--maxlogentries", "-maxlogentries", type = int, help = "The maximum number of log entries to collect in each log service" )
+    argget.add_argument( "--forcefolderrename", "-forcefolderrename", action = "store_true", help = "Indicates if URIs containing characters that are disallowed in Windows folder names are renamed to replace the characters with underscores" )
     args, unknown = argget.parse_known_args()
 
     # Convert the authentication method to something usable with the Redfish library
@@ -154,7 +155,7 @@ def scan_resource( redfish_obj, args, response_times, uri, is_csdl = False ):
     # Set up the output folder
     try:
         path = uri[1:]
-        if folder_name_fix:
+        if folder_name_fix or args.forcefolderrename:
             for character in disallowed_folder_characters_win:
                 path = path.replace( character, "_" )
         path = os.path.join( args.Dir, path )
@@ -215,7 +216,7 @@ def scan_resource( redfish_obj, args, response_times, uri, is_csdl = False ):
                 save_dict["@Redfish.Copyright"] = args.Copyright
 
             # Update the payload's URIs if they need to be corrected based on allowable folder names for the system
-            if folder_name_fix:
+            if folder_name_fix or args.forcefolderrename:
                 fix_uris( save_dict )
 
             with open( index_path, "w", encoding = "utf-8" ) as file:


### PR DESCRIPTION
Fix #79 

@shesamian please let me know if the README changes look good to you (or if you have better suggestions for the CLI option name).